### PR TITLE
Only handle normal windows.

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -36,9 +36,9 @@ function moveToNewDesktop(window) {
     newDesktop = findDesktop(window.internalId.toString());
 
     savedDesktops[window.internalId.toString()] = workspace.currentDesktop;
-    workspace.currentDesktop = newDesktop;
     ds = [newDesktop]
     window.desktops = ds
+    workspace.currentDesktop = newDesktop;
 }
 
 function restoreDesktop(window) {
@@ -71,16 +71,18 @@ function fullScreenChanged(window) {
 function install() {
     log("Installing handler for workspace window add");
     workspace.windowAdded.connect(window => {
-        log("Installing fullscreen and close handles for" + window.internalId.toString());
-        window.fullScreenChanged.connect(function () {
-            log(window.internalId.toString() + "fullscreen changed");
-            fullScreenChanged(window);
-        });
-        window.closed.connect(function () {
-            log(window.internalId.toString() + " closed");
-            restoreDesktop(window);
-        });
-
+        // Check if the window is normal
+        if(window.normalWindow){
+            log("Installing fullscreen and close handles for" + window.internalId.toString());
+            window.fullScreenChanged.connect(function () {
+                log(window.internalId.toString() + "fullscreen changed");
+                fullScreenChanged(window);
+            });
+            window.closed.connect(function () {
+                log(window.internalId.toString() + " closed");
+                restoreDesktop(window);
+            });
+        }
     });
     log("Workspacke handler installed");
 }


### PR DESCRIPTION
Only handle normal windows to avoid unnecessary handling of menus, panels and other special clients

Also fixed some behavior when panel stays active after entering full screen but changing order of assigning window to a new desktop and then switching to it.