### PR TITLE
Only handle normal and fullScreenable windows

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -71,8 +71,8 @@ function fullScreenChanged(window) {
 function install() {
     log("Installing handler for workspace window add");
     workspace.windowAdded.connect(window => {
-        // Check if the window is normal
-        if(window.normalWindow){
+        // Check if the window is normal and fullscreenable
+        if(window.normalWindow && window.fullScreenable){
             log("Installing fullscreen and close handles for" + window.internalId.toString());
             window.fullScreenChanged.connect(function () {
                 log(window.internalId.toString() + "fullscreen changed");


### PR DESCRIPTION
Additional filter for windows to prevent handling krunner and other "normal" windows.

In my case this caused plasmashell to crash when activating krunner.
Other filters might be required as well, like "&& !window.skipPager && !window.skipTaskbar"