### PR TITLE
When restoring window - raise it to the top

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -54,6 +54,7 @@ function restoreDesktop(window) {
         }
         workspace.removeDesktop(currentDesktop);
         workspace.currentDesktop = window.desktops[0];
+        workspace.raiseWindow(window);
     }
 }
 


### PR DESCRIPTION
When window is restored to it's original desktop, put it in the top of stacking order, to prevent it going below existing windows on that desktop.