### PR TITLE
Use resource name + restore all desktops + sanitize restore

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -2,17 +2,6 @@ function log(msg) {
     print("KWinMax2NewVirtualDesktop: " + msg);
 }
 
-function findDesktop(name) {
-    log("Trying to find " + name + " " + workspace.desktops);
-    for (i = 0; i < workspace.desktops.length; i++) {
-        desktop = workspace.desktops[i];
-        if (desktop.name == name) {
-            log("Found :" + desktop.name);
-            return desktop;
-        }
-    }
-}
-
 const savedDesktops = {};
 
 function getNextDesktopNumber() {
@@ -28,32 +17,47 @@ function getNextDesktopNumber() {
 }
 
 function moveToNewDesktop(window) {
-    log("Creating new desktop with name : " | window.internalId.toString());
+    log("Creating new desktop with name : " | window.resourceName.toString());
     let newDesktopNumber = getNextDesktopNumber();
 
-    workspace.createDesktop(newDesktopNumber, window.internalId.toString());
+    workspace.createDesktop(newDesktopNumber, window.resourceName.toString());
 
-    newDesktop = findDesktop(window.internalId.toString());
+    newDesktop = workspace.desktops[newDesktopNumber];
 
-    savedDesktops[window.internalId.toString()] = workspace.currentDesktop;
+    savedDesktops[window.internalId.toString()] = window.desktops;
+    log(JSON.stringify(savedDesktops))
     ds = [newDesktop]
     window.desktops = ds
     workspace.currentDesktop = newDesktop;
 }
 
+function sanitizeDesktops(desktops) {
+    log("Sanitizing desktops: " + JSON.stringify(desktops))
+    let sanitizedDesktops = desktops.filter(value => Object.keys(value).length !== 0);
+    log("sanitizeDesktops: " + JSON.stringify(sanitizedDesktops))
+    if (sanitizedDesktops.length < 1) {
+        sanitizedDesktops = [workspace.desktops[0]];
+    }
+    return sanitizedDesktops
+}
+
 function restoreDesktop(window) {
     log("Restoring desktop for " + window.internalId);
-    if (window.desktops[0].name == window.internalId.toString()) {
+    if (window.desktops[0].name == window.resourceName.toString()) {
         log("here")
         let currentDesktop = window.desktops[0];
         log(currentDesktop);
-        if (savedDesktops.hasOwnProperty(window.internalId.toString())) {
-            let desktops = [savedDesktops[window.internalId.toString()]]
+        if (window.internalId.toString() in savedDesktops ) {
+            log("Found saved desktops for: " + window.internalId.toString())
+            let desktops = sanitizeDesktops(savedDesktops[window.internalId.toString()])
+
             delete savedDesktops[window.internalId.toString()]
+            log(JSON.stringify(savedDesktops))
             window.desktops = desktops;
         }
         workspace.removeDesktop(currentDesktop);
         workspace.currentDesktop = window.desktops[0];
+        workspace.raiseWindow(window);
     }
 }
 


### PR DESCRIPTION
- Use application/resource name for new desktop
- Restore all desktops the window was before maximize
- Sanitize restored desktops, e.g. when desktop was deleted in between.

I know, those are a lot of changes in a single PR...  
Using window's resource name for new desktop just looks better (kinda imitate OSX).
The rest is just improved behavior for storing and restoring window's desktops. 